### PR TITLE
Prevent `Cannot redeclare class Sentry` error

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -30,7 +30,9 @@ class Plugin extends PluginBase
      */
     public function register()
     {
-        class_alias(\OFFLINE\Sentry\Classes\SentryFacade::class, 'Sentry');
+        if (class_exists('Sentry') === false) {
+            class_alias(\OFFLINE\Sentry\Classes\SentryFacade::class, 'Sentry');
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes #2. It doesn't break anything, I think. But I'm not really sure why creating an alias is necessary, maybe a better solution is possible.