### PR TITLE
Forcing array type when field is empty

### DIFF
--- a/classes/ExceptionHandler.php
+++ b/classes/ExceptionHandler.php
@@ -54,7 +54,7 @@ class ExceptionHandler extends \October\Rain\Foundation\Exception\Handler
      */
     protected function shouldntReport(\Throwable $e)
     {
-        $excluded = Settings::get('excluded_exceptions', []);
+        $excluded = (array)Settings::get('excluded_exceptions', []);
 
         if (in_array(get_class($e), $excluded, true)) {
             return true;


### PR DESCRIPTION
At some point it returned an empty value and not an array, causing an error in in_array.