### PR TITLE
Handle exceptions by October's handler

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -1,6 +1,6 @@
 <?php namespace OFFLINE\Sentry;
 
-use Illuminate\Contracts\Debug\ExceptionHandler;
+use Event;
 use Illuminate\Support\Facades\App;
 use OFFLINE\Sentry\Classes\Context;
 use Sentry\State\Hub;
@@ -14,15 +14,13 @@ class Plugin extends PluginBase
 
     public function register()
     {
-        $config = config('sentry');
+        Event::listen('exception.report', function (\Exception $e) {
+            $config = config('sentry');
 
-        if (!array_get($config, 'environment')) {
-            $config['environment'] = App::environment();
-        }
+            if (!array_get($config, 'environment')) {
+                $config['environment'] = App::environment();
+            }
 
-        $handler = $this->app->make(ExceptionHandler::class);
-
-        $handler->reportable(function (\Throwable $e) {
             if (!$this->app->bound('sentry')) {
                 return;
             }


### PR DESCRIPTION
I've tested this plugin with October 3.2 and it didn't report exceptions happening in the backend area. So I've rewritten handling with internal [October's Handler](https://github.com/octobercms/library/blob/3.x/src/Foundation/Exception/Handler.php#L98) and it works.

I've tested reporting from the backend and from the theme and both work.