### PR TITLE
Fix plugin description since there is no lang files

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 plugin:
-    name: 'offline.sentry::lang.plugin.name'
-    description: 'offline.sentry::lang.plugin.description'
+    name: 'Sentry'
+    description: 'Sentry integration for October CMS'
     author: OFFLINE
     icon: oc-icon-bug
     homepage: ''


### PR DESCRIPTION
Fix the plugin description since there are no language files anymore. I think no translation is needed, so I removed translation keys.

<img width="904" alt="Screenshot 2025-06-21 v 7 43 41" src="https://github.com/user-attachments/assets/8faa7e03-ea45-430f-a35c-45924d5c459c" />
